### PR TITLE
メールアドレスでの新規登録ができないようにしました

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -124,3 +124,8 @@ body {
   width: 10%
 }
 
+/** devise **/
+.devise-notice {
+ padding: 8px;
+ border: 1px solid red;
+}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,6 @@
+<%
+=begin
+%>
 <h2>登録</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
@@ -27,3 +30,13 @@
 <% end %>
 
 <%= render "devise/shared/links" %>
+<%
+=end
+%>
+<div class="row">
+  <div class="devise-notice">
+    <p>メールアドレスによる新規登録は終了しました。Twitterアカウントでのログインをご利用ください。</p>
+    <p>メールアドレスでご登録いただいた情報は2016年11月末に削除します。Twitterアカウントへのデータ引き継ぎはできません（ごめんなさい！）</p>
+  </div>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,12 @@
 <h2>ログイン</h2>
 
+<div class="row">
+  <div class="devise-notice">
+    <p>メールアドレスによるログインは2016年11月中旬で終了します。Twitterアカウントでのログインをご利用ください。</p>
+    <p>メールアドレスでご登録いただいた情報は2016年11月末に削除します。Twitterアカウントへのデータ引き継ぎはできません（ごめんなさい！）</p>
+  </div>
+</div>
+
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,10 +1,15 @@
 <%- if controller_name != 'sessions' %>
   <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end -%>
-
+<%
+=begin
+ %>
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
   <%= link_to "登録", new_registration_path(resource_name) %><br />
 <% end -%>
+<%
+=end
+%>
 <%
 =begin
  %>
@@ -25,6 +30,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to "#{OmniAuth::Utils.camelize(provider)}アカウントでログイン", omniauth_authorize_path(resource_name, provider) %><br />
   <% end -%>
 <% end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,19 +38,18 @@
 	<% end %> 
 <% end %>
 <% if user_signed_in? %>
-<%
-=begin
-%>
-<%= current_user.email %>としてログインしています。 
-<%
-=end
-%>
 ログイン中です。 
 <%= link_to "ログアウト", destroy_user_session_path, :method => :delete %>
 <% else %>
 <li><%= link_to "ログイン", new_user_session_path, :class => 'post' %></li>
 <li><%= link_to "Twitterアカウントでログイン", user_twitter_omniauth_authorize_path %></li>
+<%
+=begin
+%>
 <li><%= link_to "新規登録", new_user_registration_path, :class => 'post' %></li>
+<%
+=end
+%>
 <% end %>
 </ul>
 </div>


### PR DESCRIPTION
- users/sign_upからメールアドレスでの新規登録フォームを削除
- ヘッダからusers/sign_upへのリンクを削除
- users/sign_inにメールアドレスでのログインを終了するお知らせを追加