### PR TITLE
resultページの合計金額をわかりやすくしました

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,11 +31,7 @@
 <ul class="nav navbar-nav">
 <li><a href="/">トップ</a></li>
 <% if user_signed_in? %>
- 	<% if current_user.user_goals.exists?(finish: false)  %>
-	    <li><a href="/setting">目標確認</a></li>
-	<% else %>
-	    <li><a href="/setting">目標設定</a></li>  
-	<% end %> 
+  <li><a href="/setting">設定</a></li>
 <% end %>
 <% if user_signed_in? %>
 <%

--- a/app/views/setting/reggoal.html.erb
+++ b/app/views/setting/reggoal.html.erb
@@ -27,7 +27,13 @@
             <TD><%=goal.goalMoney.to_s %></TD>
             <TD class="goal-tweet">
 <a href="cdhttps://twitter.com/share" class="twitter-share-button" data-text="<%=goal.buttonStr.to_s %>に使いたいので<%=goal.goalMoney.to_s %>円貯めます！ #したつもり貯金 #やるで #aiit_enpit"  data-url="https://goo.gl/D6RWc0"  data-size="small">Tweet</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+<script>
+if (typeof twttr === 'undefined') {
+!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
+} else {
+ twttr.widgets.load();
+}
+</script>
 
             </TD>
 

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -22,17 +22,16 @@
            <option>9</option>
          </select>
          <% if user_signed_in? &&  current_user.endurances.exists? %>
-         <span>00円の<%= @current_endurance %></span>
+           <span>00円を、<%= @current_endurance %>かわりに</span>
          <% else %>
-         <span>00円のコーヒーを飲む</span>
+           <span>00円を、コーヒーを飲むかわりに</span>
          <% end %> 
          <% if user_signed_in? && UserGoal.find_by(:user_id => current_user.id) %>
-         <input type="submit" class="large-button" tabIndex="0" id="twitter_button" value = "かわりに<%= @usergoal.buttonStr %>に使う">
+           <input type="submit" class="large-button" tabIndex="0" id="twitter_button" value = "<%= @usergoal.buttonStr %>に使う">
          <% else %>
-         <input type="submit" class="large-button" tabIndex="0" id="twitter_button" value = "かわりに目標の為に使う">
-         </p>
-       <% end %>
-　　　　<% end %>
+           <input type="submit" class="large-button" tabIndex="0" id="twitter_button" value = "目標の為に使う">
+         <% end %>
+　　　 <% end %>
 
  </body>
 </html>

--- a/app/views/top/result.html.erb
+++ b/app/views/top/result.html.erb
@@ -9,17 +9,19 @@
   <div>
   <% if user_signed_in? %>
   <p>今回：<%= @total_before %>円</p>
-  <p>合計貯金額：<%= @total_after %>円</p>
     <% if current_user.user_goals.exists? %>
       <% if current_user.user_goals.exists?(finish: false)  %>
-        <p>目標金額：<%= current_user.user_goals.find_by(finish: false).goalMoney %>円</p>
+        <% @current_goal = current_user.user_goals.find_by(finish: false)  %>
+        <p>目標金額：<%= @current_goal.goalMoney %>円</p>
+        <p>目標まであと：<%= @current_goal.goalMoney - @current_goal.total %>円</p>
       <% else %>
         <p>目標達成！！</p>
         <a href="/setting" class="red">おめでとうございます！新しい目標を設定してみましょう</a>
       <% end %>
     <% else %>
-      <a href="/setting" class="red">目標を設定してみましょう</a>
+        <a href="/setting" class="red">目標を設定してみましょう</a>
     <% end %>
+    <p>いままでの合計貯金額：<%= @total_after %>円</p>
   <% else %>
   <p>今回：<%= @total_before %>円</p>
   <p>ログインして合計貯金額を記録しましょう</p>


### PR DESCRIPTION
細かくちょこちょこ修正しました。
- resultページの合計金額をわかりやすく
->ログインユーザには結果ページでいままでの合計金額、目標金額、目標までの金額が表示されるようにしました

- ヘッダのリンクの文言修正
->「目標設定」と「目標確認」が切り替わるようにしてもらってたんですが、目標以外も設定できるようになったので、ログインユーザには常に「設定」と表示されるようにしました

- トップページの文言修正
->100円「を」にしました。あと、「〜のかわりに」をボタンの外に出しました

- 非同期でもTweetボタンを読み込むように修正
-> 目標設定したあとにつぶやくボタンがブラウザバックするとうまく表示されなかったので、明示的に再読み込みする設定を追加しました
参考：http://qiita.com/kzhrk/items/5bc39df48dc1ab8ea850