### PR TITLE
Tweetname add

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,13 +7,14 @@ class User < ActiveRecord::Base
   has_many :endurances, dependent: :destroy
 
 def self.find_for_twitter_oauth(auth, signed_in_resource=nil)
-    user = User.where(:provider => auth.provider, :id => auth.uid).first
+     user = User.where(:provider => auth.provider, :id => auth.uid).first
     unless user
       user = User.create(
                          provider: auth.provider,
                          id:      auth.uid,
                          email:    User.create_unique_email,
-                         password: Devise.friendly_token[0,20]
+                         password: Devise.friendly_token[0,20],
+                         name: auth.info.nickname
                         )
     end
     user

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,15 +37,15 @@
 	    <li><a href="/setting">目標設定</a></li>  
 	<% end %> 
 <% end %>
+<% if user_signed_in? && current_user.name? %>
+<%= current_user.name %>としてログイン中です。
+
+<% elsif user_signed_in? %>
+ログイン中です。
+<% end %>
+
 <% if user_signed_in? %>
-<%
-=begin
-%>
-<%= current_user.email %>としてログインしています。 
-<%
-=end
-%>
-<%= current_user.name %>としてログイン中です。 
+  
 <%= link_to "ログアウト", destroy_user_session_path, :method => :delete %>
 <% else %>
 <li><%= link_to "ログイン", new_user_session_path, :class => 'post' %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
 <%
 =end
 %>
-ログイン中です。 
+<%= current_user.name %>としてログイン中です。 
 <%= link_to "ログアウト", destroy_user_session_path, :method => :delete %>
 <% else %>
 <li><%= link_to "ログイン", new_user_session_path, :class => 'post' %></li>

--- a/db/migrate/20161103083254_add_name_to_user.rb
+++ b/db/migrate/20161103083254_add_name_to_user.rb
@@ -1,0 +1,5 @@
+class AddNameToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161103060101) do
+ActiveRecord::Schema.define(version: 20161103083254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20161103060101) do
     t.datetime "updated_at",                          null: false
     t.string   "total"
     t.string   "provider"
+    t.string   "name"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1,12 +1,5 @@
 require 'test_helper'
 
 class OmniauthCallbacksControllerTest < ActionController::TestCase
-def self.from_omniauth(auth)
-    where(provider: auth.provider, id: auth.uid).first_or_create do |user|
-     user.provider = auth.provider
-     user.name = auth.info.nickname
-    end
-end
-
 
 end

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class OmniauthCallbacksControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+def self.from_omniauth(auth)
+    where(provider: auth.provider, id: auth.uid).first_or_create do |user|
+     user.provider = auth.provider
+     user.name = auth.info.nickname
+    end
+end
+
+
 end


### PR DESCRIPTION
■作業の概要
twitterでログインした時にtwitterのニックネームを取得しDBに格納。viewにtwitterのニックネームを掲出するようにしました。

■変更点
・DBにnameのカラムを追加
・OAuth認証時にnicknameをnameカラムに格納
・view側にはDBにnameの値がある時はその値を掲出、無い時はログインしましたという文言が出るように出し分け
・OAuth認証に関するコントローラーにテストコードを記述